### PR TITLE
Built "Extensions" API for BLE triggers (or anything you want)

### DIFF
--- a/EXTENSIONS/README.md
+++ b/EXTENSIONS/README.md
@@ -1,0 +1,57 @@
+# RaspyJack Extensions
+
+Author: m0usem0use
+
+This directory holds shared helpers that payloads can import when they need a reusable gate or action.
+
+The current focus is BLE-driven workflow control. Instead of embedding the same wait logic in multiple payloads, RaspyJack exposes a small extension API that any payload can call.
+
+On RaspyJack, the BLE path uses the Pi's onboard Bluetooth through BlueZ and `bluetoothctl`. It does not depend on a separate UART BLE module.
+
+## What is here
+
+- `gates.py` provides condition-style helpers such as `WAIT_FOR_PRESENT` and `WAIT_FOR_NOTPRESENT`.
+- `actions.py` provides shared actions such as `REQUIRE_CAPABILITY` and `RUN_PAYLOAD`.
+- `api.py` re-exports the public helpers for payload authors.
+- the command-line scripts in this directory are thin wrappers over the same API.
+
+## Public API
+
+Payloads should import the helpers from `EXTENSIONS.api`:
+
+```python
+from EXTENSIONS.api import (
+    WAIT_FOR_PRESENT,
+    WAIT_FOR_NOTPRESENT,
+    REQUIRE_CAPABILITY,
+    RUN_PAYLOAD,
+)
+```
+
+These imports are regular Python functions. There is no extra payload language or parser layer.
+
+## Example usage
+
+Wait until a known BLE advertiser is present, then continue:
+
+```bash
+python3 /root/Raspyjack/EXTENSIONS/wait_for_present.py --name TestRJ --timeout-seconds 30
+```
+
+Require a dependency before the payload continues:
+
+```bash
+python3 /root/Raspyjack/EXTENSIONS/require_capability.py binary bluetoothctl
+```
+
+Run another payload by relative path:
+
+```bash
+python3 /root/Raspyjack/EXTENSIONS/run_payload.py utilities/trigger_marker.py test_run
+```
+
+## Notes for payload authors
+
+- Extensions do not replace the normal payload template.
+- Interactive payloads should still use `ScaledDraw`, `scaled_font()`, and `get_button`.
+- Keeping the payload in the standard `try/finally` layout is still the right way to guarantee `LCD.LCD_Clear()` and `GPIO.cleanup()` on both supported screen sizes.

--- a/EXTENSIONS/__init__.py
+++ b/EXTENSIONS/__init__.py
@@ -1,0 +1,10 @@
+"""RaspyJack shared extension helpers."""
+
+from .api import REQUIRE_CAPABILITY, RUN_PAYLOAD, WAIT_FOR_NOTPRESENT, WAIT_FOR_PRESENT
+
+__all__ = [
+    "WAIT_FOR_PRESENT",
+    "WAIT_FOR_NOTPRESENT",
+    "REQUIRE_CAPABILITY",
+    "RUN_PAYLOAD",
+]

--- a/EXTENSIONS/_bluez.py
+++ b/EXTENSIONS/_bluez.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""
+Shared BlueZ-backed helpers for RaspyJack extensions.
+Author: m0usem0use
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+import time
+
+
+DEVICE_RE = re.compile(r"Device ([0-9A-F:]{17})(?:\s+(.*))?$")
+UUID_LINE_RE = re.compile(
+    r"UUID:\s+.*?\(([0-9A-Fa-f-]{36}|[0-9A-Fa-f]{4,8})\)\s*$|UUID:\s+([0-9A-Fa-f-]{36}|[0-9A-Fa-f]{4,8})\s*$"
+)
+UUID_TOKEN_RE = re.compile(r"([0-9A-Fa-f-]{36}|[0-9A-Fa-f]{4,8})")
+BLUETOOTH_BASE_SUFFIX = "-0000-1000-8000-00805f9b34fb"
+SCAN_PROPERTY_PREFIXES = (
+    "RSSI:",
+    "TxPower:",
+    "ManufacturerData",
+    "ServiceData",
+    "UUID:",
+    "UUIDs:",
+    "Alias:",
+    "Paired:",
+    "Trusted:",
+    "Blocked:",
+    "Connected:",
+    "LegacyPairing:",
+)
+
+
+def normalize_service_uuid(value: str | None) -> str | None:
+    if not value:
+        return None
+    match = UUID_TOKEN_RE.search(str(value).strip())
+    if not match:
+        return None
+    token = match.group(1).lower()
+    compact = token.replace("-", "")
+    if len(compact) == 4:
+        return f"0000{compact}{BLUETOOTH_BASE_SUFFIX}"
+    if len(compact) == 8:
+        return f"{compact}{BLUETOOTH_BASE_SUFFIX}"
+    if len(compact) == 32:
+        return (
+            f"{compact[0:8]}-{compact[8:12]}-{compact[12:16]}-"
+            f"{compact[16:20]}-{compact[20:32]}"
+        )
+    return None
+
+
+def _clean_scan_name(value: str | None) -> str:
+    name = (value or "").strip()
+    if not name:
+        return ""
+    if any(name.startswith(prefix) for prefix in SCAN_PROPERTY_PREFIXES):
+        return ""
+    return name
+
+
+def _run_command(cmd: list[str], timeout_seconds: int) -> subprocess.CompletedProcess[str] | None:
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_seconds)
+    except (OSError, subprocess.SubprocessError, subprocess.TimeoutExpired):
+        return None
+
+
+def ensure_bluetooth_ready() -> dict[str, str | bool]:
+    if shutil.which("rfkill"):
+        _run_command(["rfkill", "unblock", "bluetooth"], timeout_seconds=4)
+        _run_command(["rfkill", "unblock", "all"], timeout_seconds=4)
+    if shutil.which("hciconfig"):
+        _run_command(["hciconfig", "hci0", "up"], timeout_seconds=5)
+    if shutil.which("bluetoothctl"):
+        _run_command(["bluetoothctl", "power", "on"], timeout_seconds=5)
+
+    show = _run_command(["bluetoothctl", "show"], timeout_seconds=6)
+    output = (show.stdout if show else "") or ""
+    powered = "unknown"
+    power_state = "unknown"
+    for line in output.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("Powered:"):
+            powered = stripped.split(":", 1)[1].strip().lower()
+        elif stripped.startswith("PowerState:"):
+            power_state = stripped.split(":", 1)[1].strip().lower()
+    return {
+        "ready": powered == "yes",
+        "powered": powered,
+        "power_state": power_state,
+    }
+
+
+def parse_bluetoothctl_info(text: str, mac: str, name: str = "") -> dict[str, object]:
+    service_uuids: list[str] = []
+    current_name = name
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("Name:"):
+            current_name = line.split(":", 1)[1].strip() or current_name
+            continue
+        uuid_match = UUID_LINE_RE.search(line)
+        if not uuid_match:
+            continue
+        normalized = normalize_service_uuid(uuid_match.group(1) or uuid_match.group(2))
+        if normalized and normalized not in service_uuids:
+            service_uuids.append(normalized)
+    return {
+        "mac": mac.upper(),
+        "name": current_name,
+        "service_uuids": service_uuids,
+    }
+
+
+def read_bluetoothctl_info(mac: str, timeout_seconds: int = 8) -> dict[str, object]:
+    proc = _run_command(["bluetoothctl", "info", mac], timeout_seconds=timeout_seconds)
+    if not proc:
+        return {"mac": mac.upper(), "name": "", "service_uuids": []}
+    return parse_bluetoothctl_info(proc.stdout or "", mac=mac)
+
+
+def scan_ble(window_seconds: int, include_service_uuids: bool = False) -> list[dict[str, object]]:
+    proc = _run_command(
+        ["bluetoothctl", "--timeout", str(window_seconds), "scan", "on"],
+        timeout_seconds=window_seconds + 5,
+    )
+    scan_text = ""
+    if proc:
+        scan_text = (proc.stdout or "") + ("\n" + proc.stderr if proc.stderr else "")
+
+    seen: dict[str, dict[str, object]] = {}
+    for line in scan_text.splitlines():
+        match = DEVICE_RE.search(line)
+        if not match:
+            continue
+        mac = match.group(1).upper()
+        name = _clean_scan_name(match.group(2) or "")
+        if mac not in seen:
+            seen[mac] = {"mac": mac, "name": name, "service_uuids": []}
+        elif name and not seen[mac]["name"]:
+            seen[mac]["name"] = name
+
+    if include_service_uuids:
+        info_timeout = max(4, window_seconds + 2)
+        for mac, dev in seen.items():
+            details = read_bluetoothctl_info(mac, timeout_seconds=info_timeout)
+            if details.get("name") and not dev.get("name"):
+                dev["name"] = details["name"]
+            dev["service_uuids"] = list(details.get("service_uuids") or [])
+    return list(seen.values())
+
+
+def device_matches(
+    device: dict[str, object],
+    *,
+    name: str = "",
+    mac: str = "",
+    service_uuid: str = "",
+) -> bool:
+    if mac and str(device.get("mac", "")).upper() != str(mac).upper():
+        return False
+    if name and str(device.get("name", "")) != name:
+        return False
+    if service_uuid:
+        normalized = normalize_service_uuid(service_uuid)
+        values = {normalize_service_uuid(item) for item in (device.get("service_uuids") or [])}
+        if normalized not in values:
+            return False
+    return True
+
+
+def devices_match(
+    devices: list[dict[str, object]],
+    *,
+    name: str = "",
+    mac: str = "",
+    service_uuid: str = "",
+) -> bool:
+    return any(
+        device_matches(device, name=name, mac=mac, service_uuid=service_uuid)
+        for device in devices
+    )
+
+
+def wait_for_match(
+    *,
+    expect_present: bool,
+    name: str = "",
+    mac: str = "",
+    service_uuid: str = "",
+    timeout_seconds: int = 0,
+    scan_window_seconds: int = 4,
+    poll_interval_seconds: int = 2,
+) -> int:
+    normalized_name = str(name or "").strip()
+    normalized_mac = str(mac or "").strip().upper()
+    normalized_uuid = normalize_service_uuid(service_uuid)
+    if not (normalized_name or normalized_mac or normalized_uuid):
+        raise ValueError("at least one of --name, --mac, or --service-uuid is required")
+
+    bt_state = ensure_bluetooth_ready()
+    if not bt_state.get("ready"):
+        print(
+            f"Bluetooth unavailable: powered={bt_state.get('powered')} "
+            f"power_state={bt_state.get('power_state')}",
+            file=sys.stderr,
+        )
+        return 2
+
+    deadline = time.monotonic() + timeout_seconds if timeout_seconds > 0 else None
+    while True:
+        devices = scan_ble(
+            max(1, scan_window_seconds),
+            include_service_uuids=bool(normalized_uuid),
+        )
+        matched = devices_match(
+            devices,
+            name=normalized_name,
+            mac=normalized_mac,
+            service_uuid=normalized_uuid or "",
+        )
+        if expect_present and matched:
+            return 0
+        if not expect_present and not matched:
+            return 0
+        if deadline is not None and time.monotonic() >= deadline:
+            return 1
+        time.sleep(max(1, poll_interval_seconds))
+
+
+def add_common_wait_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    parser.add_argument("--name", default="")
+    parser.add_argument("--mac", default="")
+    parser.add_argument("--service-uuid", default="")
+    parser.add_argument("--timeout-seconds", type=int, default=0)
+    parser.add_argument("--scan-window-seconds", type=int, default=4)
+    parser.add_argument("--poll-interval-seconds", type=int, default=2)
+    return parser

--- a/EXTENSIONS/actions.py
+++ b/EXTENSIONS/actions.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Shared action helpers for RaspyJack extensions. Author: m0usem0use"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PAYLOAD_ROOT = REPO_ROOT / "payloads"
+
+
+def REQUIRE_CAPABILITY(
+    capability_type: str,
+    value: str,
+    *,
+    failure_policy: str = "fail_closed",
+) -> bool:
+    capability_type = str(capability_type).strip().lower()
+    value = str(value).strip()
+    if capability_type not in {"binary", "service", "interface", "config"}:
+        raise ValueError(f"unsupported capability_type: {capability_type}")
+    if not value:
+        raise ValueError("value is required")
+
+    if capability_type == "binary":
+        ok = shutil.which(value) is not None
+    elif capability_type == "service":
+        try:
+            result = subprocess.run(
+                ["systemctl", "is-active", "--quiet", value],
+                capture_output=True,
+                timeout=5,
+            )
+            ok = result.returncode == 0
+        except (OSError, subprocess.SubprocessError, subprocess.TimeoutExpired):
+            ok = False
+    elif capability_type == "interface":
+        try:
+            result = subprocess.run(
+                ["ip", "link", "show", value],
+                capture_output=True,
+                timeout=5,
+            )
+            ok = result.returncode == 0
+        except (OSError, subprocess.SubprocessError, subprocess.TimeoutExpired):
+            ok = False
+    else:
+        raw = Path(value)
+        target = raw if raw.is_absolute() else (REPO_ROOT / raw)
+        ok = target.exists()
+
+    if ok:
+        return True
+    if str(failure_policy).strip().lower() == "warn_only":
+        return False
+    raise RuntimeError(f"missing required capability: {capability_type}={value}")
+
+
+def RUN_PAYLOAD(payload: str, *payload_args: str) -> int:
+    payload_path = (PAYLOAD_ROOT / payload).resolve()
+    try:
+        payload_root = PAYLOAD_ROOT.resolve()
+    except FileNotFoundError:
+        payload_root = PAYLOAD_ROOT
+    if payload_root not in payload_path.parents:
+        raise ValueError("payload path escapes payload root")
+    if not payload_path.is_file():
+        raise FileNotFoundError(f"payload not found: {payload_path}")
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+    cmd = ["python3", str(payload_path), *payload_args]
+    return subprocess.run(cmd, cwd=str(REPO_ROOT), env=env).returncode

--- a/EXTENSIONS/api.py
+++ b/EXTENSIONS/api.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Public extension API for RaspyJack payloads. Author: m0usem0use"""
+from __future__ import annotations
+
+try:
+    from .actions import REQUIRE_CAPABILITY, RUN_PAYLOAD
+    from .gates import WAIT_FOR_NOTPRESENT, WAIT_FOR_PRESENT
+except ImportError:
+    from actions import REQUIRE_CAPABILITY, RUN_PAYLOAD
+    from gates import WAIT_FOR_NOTPRESENT, WAIT_FOR_PRESENT
+
+__all__ = [
+    "WAIT_FOR_PRESENT",
+    "WAIT_FOR_NOTPRESENT",
+    "REQUIRE_CAPABILITY",
+    "RUN_PAYLOAD",
+]

--- a/EXTENSIONS/gates.py
+++ b/EXTENSIONS/gates.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Shared gate helpers for RaspyJack extensions. Author: m0usem0use"""
+from __future__ import annotations
+
+try:
+    from ._bluez import wait_for_match
+except ImportError:
+    from _bluez import wait_for_match
+
+
+def _handle_wait_result(result: int, *, fail_closed: bool, condition: str) -> bool:
+    if result == 0:
+        return True
+    if not fail_closed:
+        return False
+    if result == 1:
+        raise TimeoutError(f"{condition} timed out")
+    raise RuntimeError(f"{condition} failed because Bluetooth is unavailable")
+
+
+def WAIT_FOR_PRESENT(
+    *,
+    name: str = "",
+    mac: str = "",
+    service_uuid: str = "",
+    timeout_seconds: int = 0,
+    scan_window_seconds: int = 4,
+    poll_interval_seconds: int = 2,
+    fail_closed: bool = True,
+) -> bool:
+    result = wait_for_match(
+        expect_present=True,
+        name=name,
+        mac=mac,
+        service_uuid=service_uuid,
+        timeout_seconds=timeout_seconds,
+        scan_window_seconds=scan_window_seconds,
+        poll_interval_seconds=poll_interval_seconds,
+    )
+    return _handle_wait_result(result, fail_closed=fail_closed, condition="WAIT_FOR_PRESENT")
+
+
+def WAIT_FOR_NOTPRESENT(
+    *,
+    name: str = "",
+    mac: str = "",
+    service_uuid: str = "",
+    timeout_seconds: int = 0,
+    scan_window_seconds: int = 4,
+    poll_interval_seconds: int = 2,
+    fail_closed: bool = True,
+) -> bool:
+    result = wait_for_match(
+        expect_present=False,
+        name=name,
+        mac=mac,
+        service_uuid=service_uuid,
+        timeout_seconds=timeout_seconds,
+        scan_window_seconds=scan_window_seconds,
+        poll_interval_seconds=poll_interval_seconds,
+    )
+    return _handle_wait_result(result, fail_closed=fail_closed, condition="WAIT_FOR_NOTPRESENT")

--- a/EXTENSIONS/manifests/require_capability.json
+++ b/EXTENSIONS/manifests/require_capability.json
@@ -1,0 +1,34 @@
+{
+  "id": "require_capability",
+  "name": "REQUIRE_CAPABILITY",
+  "summary": "Validate that required tooling, radio hardware, or services exist before a payload is launched.",
+  "stage": "preflight",
+  "inspired_by": "hak5/bashbunny requiretool.sh",
+  "compatible_payload_tags": [
+    "bluetooth",
+    "wifi",
+    "network",
+    "ui",
+    "utility"
+  ],
+  "parameters": [
+    {
+      "name": "capability_type",
+      "type": "enum:binary|service|interface|config",
+      "required": true,
+      "description": "Type of dependency to validate."
+    },
+    {
+      "name": "value",
+      "type": "string",
+      "required": true,
+      "description": "Dependency identifier, such as hciconfig, wlan1, or caddy."
+    },
+    {
+      "name": "failure_policy",
+      "type": "enum:fail_closed|warn_only",
+      "required": false,
+      "description": "Default is fail_closed to keep execution predictable."
+    }
+  ]
+}

--- a/EXTENSIONS/manifests/run_payload.json
+++ b/EXTENSIONS/manifests/run_payload.json
@@ -1,0 +1,35 @@
+{
+  "id": "run_payload",
+  "name": "RUN_PAYLOAD",
+  "summary": "Dispatch a selected payload after trigger and preflight extensions succeed.",
+  "stage": "dispatch",
+  "inspired_by": "hak5/bashbunny runpayload.sh",
+  "compatible_payload_tags": [
+    "bluetooth",
+    "wifi",
+    "network",
+    "ui",
+    "utility",
+    "trigger"
+  ],
+  "parameters": [
+    {
+      "name": "payload_id",
+      "type": "string",
+      "required": true,
+      "description": "Identifier of the payload to execute."
+    },
+    {
+      "name": "selector_mode",
+      "type": "enum:auto|manual|policy",
+      "required": false,
+      "description": "How the payload is chosen in multi-payload flows."
+    },
+    {
+      "name": "cooldown_seconds",
+      "type": "integer",
+      "required": false,
+      "description": "Optional cooldown to avoid repeated immediate launches."
+    }
+  ]
+}

--- a/EXTENSIONS/manifests/wait_for_not_present.json
+++ b/EXTENSIONS/manifests/wait_for_not_present.json
@@ -1,0 +1,33 @@
+{
+  "id": "wait_for_not_present",
+  "name": "WAIT_FOR_NOT_PRESENT",
+  "summary": "Hold execution until a watched signal disappears from the environment.",
+  "stage": "trigger",
+  "inspired_by": "hak5/bashbunny wait_for_notpresent.sh",
+  "compatible_payload_tags": [
+    "bluetooth",
+    "wifi",
+    "gpio",
+    "trigger"
+  ],
+  "parameters": [
+    {
+      "name": "signal_type",
+      "type": "enum:bluetooth|wifi|gpio",
+      "required": true,
+      "description": "Signal family to monitor."
+    },
+    {
+      "name": "identifier",
+      "type": "string",
+      "required": true,
+      "description": "Name, MAC, SSID, or GPIO label to watch for disappearance."
+    },
+    {
+      "name": "grace_seconds",
+      "type": "integer",
+      "required": false,
+      "description": "Debounce window before absence is treated as real."
+    }
+  ]
+}

--- a/EXTENSIONS/manifests/wait_for_present.json
+++ b/EXTENSIONS/manifests/wait_for_present.json
@@ -1,0 +1,33 @@
+{
+  "id": "wait_for_present",
+  "name": "WAIT_FOR_PRESENT",
+  "summary": "Pause payload dispatch until a watched Bluetooth, Wi-Fi, or GPIO signal is present.",
+  "stage": "trigger",
+  "inspired_by": "hak5/bashbunny wait_for_present.sh",
+  "compatible_payload_tags": [
+    "bluetooth",
+    "wifi",
+    "gpio",
+    "trigger"
+  ],
+  "parameters": [
+    {
+      "name": "signal_type",
+      "type": "enum:bluetooth|wifi|gpio",
+      "required": true,
+      "description": "Signal family to monitor."
+    },
+    {
+      "name": "identifier",
+      "type": "string",
+      "required": true,
+      "description": "Name, MAC, SSID, or GPIO label to match."
+    },
+    {
+      "name": "timeout_seconds",
+      "type": "integer",
+      "required": false,
+      "description": "Optional upper bound before the trigger fails closed."
+    }
+  ]
+}

--- a/EXTENSIONS/require_capability.py
+++ b/EXTENSIONS/require_capability.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""CLI wrapper for REQUIRE_CAPABILITY. Author: m0usem0use"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+from api import REQUIRE_CAPABILITY
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check whether a required capability is available.")
+    parser.add_argument("capability_type", choices=["binary", "service", "interface", "config"])
+    parser.add_argument("value")
+    parser.add_argument("--failure-policy", choices=["fail_closed", "warn_only"], default="fail_closed")
+    args = parser.parse_args()
+    try:
+        ok = REQUIRE_CAPABILITY(
+            args.capability_type,
+            args.value,
+            failure_policy=args.failure_policy,
+        )
+        print(f"{args.capability_type}:{args.value}={'ok' if ok else 'missing'}")
+        return 0 if ok else 1
+    except (RuntimeError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/EXTENSIONS/run_payload.py
+++ b/EXTENSIONS/run_payload.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""CLI wrapper for RUN_PAYLOAD. Author: m0usem0use"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+from api import RUN_PAYLOAD
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run a RaspyJack payload by relative path.")
+    parser.add_argument("payload")
+    parser.add_argument("payload_args", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    try:
+        return RUN_PAYLOAD(args.payload, *args.payload_args)
+    except (ValueError, FileNotFoundError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/EXTENSIONS/wait_for_not_present.py
+++ b/EXTENSIONS/wait_for_not_present.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""CLI wrapper for WAIT_FOR_NOTPRESENT. Author: m0usem0use"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+from _bluez import add_common_wait_args
+from api import WAIT_FOR_NOTPRESENT
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Wait until a BLE target is no longer present.")
+    add_common_wait_args(parser)
+    args = parser.parse_args()
+    try:
+        WAIT_FOR_NOTPRESENT(
+            name=args.name,
+            mac=args.mac,
+            service_uuid=args.service_uuid,
+            timeout_seconds=args.timeout_seconds,
+            scan_window_seconds=args.scan_window_seconds,
+            poll_interval_seconds=args.poll_interval_seconds,
+        )
+        return 0
+    except TimeoutError:
+        return 1
+    except (RuntimeError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/EXTENSIONS/wait_for_present.py
+++ b/EXTENSIONS/wait_for_present.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""CLI wrapper for WAIT_FOR_PRESENT. Author: m0usem0use"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+from _bluez import add_common_wait_args
+from api import WAIT_FOR_PRESENT
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Wait until a BLE target is present.")
+    add_common_wait_args(parser)
+    args = parser.parse_args()
+    try:
+        WAIT_FOR_PRESENT(
+            name=args.name,
+            mac=args.mac,
+            service_uuid=args.service_uuid,
+            timeout_seconds=args.timeout_seconds,
+            scan_window_seconds=args.scan_window_seconds,
+            poll_interval_seconds=args.poll_interval_seconds,
+        )
+        return 0
+    except TimeoutError:
+        return 1
+    except (RuntimeError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ RaspyJack is for **authorized security testing, research, and education only**.
 - Loot collection + browsing
 - WebUI remote control dashboard
 - Payload IDE (browser editor + run flow)
+- `EXTENSIONS/` work area for reusable trigger and dispatch helpers
 - Vendored Ragnar port with native Raspyjack launcher
 - Responder / DNS spoof / ARP MITM / handshake hunter tooling integration
 - WiFi utilities + attack flows (deauth, evil twin, SSID injection, beacon flood)
@@ -310,6 +311,27 @@ finally:
     LCD.LCD_Clear()
     GPIO.cleanup()
 ```
+
+### Extensions
+
+Payloads can also import shared helpers from `EXTENSIONS.api` when they need a reusable gate or action.
+
+```python
+from EXTENSIONS.api import WAIT_FOR_PRESENT, REQUIRE_CAPABILITY
+
+try:
+    REQUIRE_CAPABILITY("binary", "bluetoothctl")
+    WAIT_FOR_PRESENT(name="TestRJ", timeout_seconds=30)
+    while True:
+        btn = get_button(PINS, GPIO)
+        if btn == "KEY3":
+            break
+finally:
+    LCD.LCD_Clear()
+    GPIO.cleanup()
+```
+
+These helpers do not change the display model. If a payload draws to the LCD, it should still use `ScaledDraw` and `scaled_font()` so the same code works on both supported screens.
 
 ---
 

--- a/payloads/examples/_payload_template.py
+++ b/payloads/examples/_payload_template.py
@@ -3,6 +3,17 @@
 RaspyJack Payload Template (WebUI + GPIO compatible)
 ---------------------------------------------------
 Use this as a starting point for custom payloads.
+
+Optional extension API:
+
+- WAIT_FOR_PRESENT
+- WAIT_FOR_NOTPRESENT
+- REQUIRE_CAPABILITY
+- RUN_PAYLOAD
+
+Those helpers live in `EXTENSIONS.api` and can be used before or during the
+main payload loop. The default template behavior below stays interactive and
+keeps `KEY3` as the exit button.
 """
 
 import os
@@ -19,6 +30,16 @@ from payloads._display_helper import ScaledDraw, scaled_font
 
 # WebUI + GPIO input helper
 from payloads._input_helper import get_button
+
+# Optional shared extension helpers.
+# Uncomment what you need for a given payload.
+#
+# from EXTENSIONS.api import (
+#     WAIT_FOR_PRESENT,
+#     WAIT_FOR_NOTPRESENT,
+#     REQUIRE_CAPABILITY,
+#     RUN_PAYLOAD,
+# )
 
 PINS = {
     "UP": 6,
@@ -52,17 +73,30 @@ def draw(lines):
 
 
 def main():
-    draw(["Payload ready", "KEY3 = exit"])
-    while True:
-        btn = get_button(PINS, GPIO)
-        if btn == "KEY3":
-            break
-        if btn:
-            draw([f"Pressed: {btn}"])
-        time.sleep(0.05)
+    try:
+        # Example gate usage before entering the interactive loop:
+        #
+        # REQUIRE_CAPABILITY("binary", "bluetoothctl")
+        # WAIT_FOR_PRESENT(
+        #     name="RJTRIG-A",
+        #     service_uuid="7f7b0001-2b7a-4e10-a6be-8e4f9d41c101",
+        #     timeout_seconds=30,
+        # )
+        #
+        # Example action chaining:
+        # RUN_PAYLOAD("utilities/trigger_marker.py", "template_demo")
 
-    LCD.LCD_Clear()
-    GPIO.cleanup()
+        draw(["Payload ready", "KEY3 = exit"])
+        while True:
+            btn = get_button(PINS, GPIO)
+            if btn == "KEY3":
+                break
+            if btn:
+                draw([f"Pressed: {btn}"])
+            time.sleep(0.05)
+    finally:
+        LCD.LCD_Clear()
+        GPIO.cleanup()
 
 
 if __name__ == "__main__":

--- a/payloads/utilities/test_ble_wait_for_present.py
+++ b/payloads/utilities/test_ble_wait_for_present.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""
+Simple BLE extension tester for RaspyJack.
+Author: m0usem0use
+
+Waits for a BLE advertiser named TestRJ, then launches the marker payload so
+validation is visible in artifacts/triggers/trigger_marker.log.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(__file__, "..", "..", "..")))
+
+from EXTENSIONS.api import REQUIRE_CAPABILITY, RUN_PAYLOAD, WAIT_FOR_PRESENT
+
+
+DEFAULT_NAME = "TestRJ"
+DEFAULT_TIMEOUT = 60
+DEFAULT_LABEL = "test_ble_wait_for_present"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(argv or sys.argv[1:])
+    target_name = args[0] if args else DEFAULT_NAME
+    timeout_seconds = int(args[1]) if len(args) > 1 else DEFAULT_TIMEOUT
+    label = args[2] if len(args) > 2 else f"{DEFAULT_LABEL}:{target_name}"
+
+    try:
+        REQUIRE_CAPABILITY("binary", "bluetoothctl")
+        print(f"waiting for BLE advertiser: {target_name} (timeout={timeout_seconds}s)")
+        WAIT_FOR_PRESENT(name=target_name, timeout_seconds=timeout_seconds)
+        print(f"matched BLE advertiser: {target_name}")
+        return RUN_PAYLOAD("utilities/trigger_marker.py", label)
+    except TimeoutError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    except (RuntimeError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/payloads/utilities/trigger_marker.py
+++ b/payloads/utilities/trigger_marker.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+Simple marker payload for BLE trigger validation.
+Author: m0usem0use
+
+This payload gives a low-friction verification target during first trigger
+bring-up: it appends a timestamped line to artifacts/triggers/trigger_marker.log.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import time
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LOG_DIR = REPO_ROOT / "artifacts" / "triggers"
+LOG_FILE = LOG_DIR / "trigger_marker.log"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(argv or sys.argv[1:])
+    label = args[0] if args else "trigger_marker"
+    ts = time.strftime("%Y-%m-%d %H:%M:%S")
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    with LOG_FILE.open("a", encoding="utf-8") as fh:
+        fh.write(f"[{ts}] {label}\n")
+    print(f"trigger marker written: {label}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import EXTENSIONS._bluez as BLUEZ
+from EXTENSIONS.api import REQUIRE_CAPABILITY, WAIT_FOR_NOTPRESENT, WAIT_FOR_PRESENT
+
+
+class ExtensionTests(unittest.TestCase):
+    def test_wait_requires_identifier(self):
+        with self.assertRaises(ValueError):
+            BLUEZ.wait_for_match(expect_present=True, timeout_seconds=1)
+
+    def test_normalize_service_uuid_expands_short_form(self):
+        self.assertEqual(
+            BLUEZ.normalize_service_uuid("180d"),
+            "0000180d-0000-1000-8000-00805f9b34fb",
+        )
+
+    def test_clean_scan_name_rejects_property_updates(self):
+        self.assertEqual(BLUEZ._clean_scan_name("RSSI: 0xffffffae (-82)"), "")
+        self.assertEqual(BLUEZ._clean_scan_name("ManufacturerData Key: 0x004c"), "")
+        self.assertEqual(BLUEZ._clean_scan_name("QHM-S35D"), "QHM-S35D")
+
+    def test_parse_bluetoothctl_info_extracts_name_and_uuids(self):
+        sample = """
+Device D6:70:43:52:A1:01
+        Name: RJTRIG-A
+        Alias: RJTRIG-A
+        UUID: Vendor specific           (7f7b0001-2b7a-4e10-a6be-8e4f9d41c101)
+        UUID: Heart Rate                (0000180d-0000-1000-8000-00805f9b34fb)
+"""
+        parsed = BLUEZ.parse_bluetoothctl_info(sample, mac="D6:70:43:52:A1:01")
+        self.assertEqual(parsed["name"], "RJTRIG-A")
+        self.assertEqual(parsed["mac"], "D6:70:43:52:A1:01")
+        self.assertIn("7f7b0001-2b7a-4e10-a6be-8e4f9d41c101", parsed["service_uuids"])
+        self.assertIn("0000180d-0000-1000-8000-00805f9b34fb", parsed["service_uuids"])
+
+    def test_wait_for_present_returns_success_on_match(self):
+        with mock.patch.object(BLUEZ, "ensure_bluetooth_ready", return_value={"ready": True}):
+            with mock.patch.object(
+                BLUEZ,
+                "scan_ble",
+                return_value=[{"name": "RJTRIG-A", "mac": "AA:BB:CC:DD:EE:FF", "service_uuids": []}],
+            ):
+                rc = BLUEZ.wait_for_match(expect_present=True, name="RJTRIG-A", timeout_seconds=1)
+        self.assertEqual(rc, 0)
+
+    def test_wait_for_not_present_returns_success_when_missing(self):
+        with mock.patch.object(BLUEZ, "ensure_bluetooth_ready", return_value={"ready": True}):
+            with mock.patch.object(BLUEZ, "scan_ble", return_value=[]):
+                rc = BLUEZ.wait_for_match(expect_present=False, name="RJTRIG-A", timeout_seconds=1)
+        self.assertEqual(rc, 0)
+
+    def test_wait_returns_timeout(self):
+        with mock.patch.object(BLUEZ, "ensure_bluetooth_ready", return_value={"ready": True}):
+            with mock.patch.object(BLUEZ, "scan_ble", return_value=[]):
+                with mock.patch.object(BLUEZ.time, "sleep", return_value=None):
+                    rc = BLUEZ.wait_for_match(
+                        expect_present=True,
+                        name="RJTRIG-A",
+                        timeout_seconds=1,
+                        scan_window_seconds=1,
+                        poll_interval_seconds=1,
+                    )
+        self.assertEqual(rc, 1)
+
+    def test_api_wait_for_present_returns_true(self):
+        with mock.patch.object(BLUEZ, "ensure_bluetooth_ready", return_value={"ready": True}):
+            with mock.patch.object(
+                BLUEZ,
+                "scan_ble",
+                return_value=[{"name": "RJTRIG-A", "mac": "AA:BB:CC:DD:EE:FF", "service_uuids": []}],
+            ):
+                self.assertTrue(WAIT_FOR_PRESENT(name="RJTRIG-A", timeout_seconds=1))
+
+    def test_api_wait_for_present_can_warn_only(self):
+        with mock.patch.object(BLUEZ, "ensure_bluetooth_ready", return_value={"ready": True}):
+            with mock.patch.object(BLUEZ, "scan_ble", return_value=[]):
+                with mock.patch.object(BLUEZ.time, "sleep", return_value=None):
+                    self.assertFalse(
+                        WAIT_FOR_PRESENT(
+                            name="RJTRIG-A",
+                            timeout_seconds=1,
+                            scan_window_seconds=1,
+                            poll_interval_seconds=1,
+                            fail_closed=False,
+                        )
+                    )
+
+    def test_api_wait_for_not_present_returns_true(self):
+        with mock.patch.object(BLUEZ, "ensure_bluetooth_ready", return_value={"ready": True}):
+            with mock.patch.object(BLUEZ, "scan_ble", return_value=[]):
+                self.assertTrue(WAIT_FOR_NOTPRESENT(name="RJTRIG-A", timeout_seconds=1))
+
+    def test_require_capability_warn_only_returns_false(self):
+        self.assertFalse(
+            REQUIRE_CAPABILITY("config", "definitely_missing_file.xyz", failure_policy="warn_only")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Using Bluez + creating universal API's, you can now call functions like "WAIT_FOR_PRESENT" + "WAIT_FOR_NOTPRESENT" globally.  Any script you want to write or any existing script you want to edit, you now can do so without writing long ass code at the top of the payload.  I adapted this concept from Hak5 but took a lot of tweaking.  Their code uses UART which works a lot better I'm not sure if it will work on our project.  So, thanks to Darren, Korben, Peaks, MG, Cribbit, et. al.  Tested + verified.