### PR TITLE
fix: button orientation broken when display is flipped 180°

### DIFF
--- a/payloads/reconnaissance/honeypot.py
+++ b/payloads/reconnaissance/honeypot.py
@@ -60,7 +60,7 @@ DEBUG_LOG = LOOT_DIR / "honeypot_debug.log"
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
-from payloads._input_helper import get_virtual_button
+from payloads._input_helper import get_button, get_virtual_button
 from payloads._display_helper import ScaledDraw, scaled_font
 
 # ---------------------------------------------------------------------------
@@ -826,12 +826,8 @@ class HoneypotLCD:
 
     def _pressed(self, name: str) -> bool:
         now = time.time()
-        virtual = get_virtual_button()
-        if virtual == name and (now - self._last_pressed[name]) > self._debounce_s:
-            self._last_pressed[name] = now
-            return True
-        pin = self.PINS[name]
-        if GPIO.input(pin) == 0 and (now - self._last_pressed[name]) > self._debounce_s:
+        btn = get_button(self.PINS, GPIO)
+        if btn == name and (now - self._last_pressed[name]) > self._debounce_s:
             self._last_pressed[name] = now
             return True
         return False

--- a/payloads/sdr/sdr_adsb.py
+++ b/payloads/sdr/sdr_adsb.py
@@ -62,14 +62,13 @@ _shutdown = threading.Event()
 
 def _btn():
     global _last_btn
-    for name, pin in PINS.items():
-        if GPIO.input(pin) == 0:
-            now = time.time()
-            if now - _last_btn < DEBOUNCE:
-                return None
-            _last_btn = now
-            return name
-    return None
+    btn = get_button(PINS, GPIO)
+    if btn:
+        now = time.time()
+        if now - _last_btn < DEBOUNCE:
+            return None
+        _last_btn = now
+    return btn
 
 
 # ---------------------------------------------------------------------------

--- a/payloads/sdr/sdr_subghz.py
+++ b/payloads/sdr/sdr_subghz.py
@@ -98,14 +98,13 @@ signal.signal(signal.SIGTERM, _sig)
 
 def _btn():
     global _last_btn
-    for name, pin in PINS.items():
-        if GPIO.input(pin) == 0:
-            now = time.time()
-            if now - _last_btn < DEBOUNCE:
-                return None
-            _last_btn = now
-            return name
-    return None
+    btn = get_button(PINS, GPIO)
+    if btn:
+        now = time.time()
+        if now - _last_btn < DEBOUNCE:
+            return None
+        _last_btn = now
+    return btn
 
 
 def _categorize(model, protocol_name):

--- a/payloads/utilities/fast_wifi_switcher.py
+++ b/payloads/utilities/fast_wifi_switcher.py
@@ -37,6 +37,7 @@ try:
     from PIL import Image, ImageDraw, ImageFont
     from payloads._display_helper import ScaledDraw, scaled_font
     from payloads._input_helper import get_virtual_button
+    from payloads._input_helper import _flip as _flip_btn
     
     # Import WiFi integration functions
     from wifi.raspyjack_integration import (
@@ -194,7 +195,7 @@ class FastWiFiSwitcher:
             if self.button_states[pin] == 1 and current_state == 0:
                 # Debouncing - ignore if pressed too recently
                 if current_time - self.last_press_time[pin] > 0.1:  # 100ms debounce
-                    pressed_buttons.append(button_name)
+                    pressed_buttons.append(_flip_btn(button_name))
                     self.last_press_time[pin] = current_time
             
             self.button_states[pin] = current_state

--- a/wifi/wifi_lcd_interface.py
+++ b/wifi/wifi_lcd_interface.py
@@ -28,12 +28,17 @@ try:
     import LCD_1in44, LCD_Config
     from PIL import Image, ImageDraw, ImageFont
     import RPi.GPIO as GPIO
+    from payloads._input_helper import get_button
     from wifi_manager import WiFiManager
     from payloads._display_helper import ScaledDraw, scaled_font
     LCD_AVAILABLE = True
 except Exception as e:
     print(f"LCD not available: {e}")
     LCD_AVAILABLE = False
+
+PINS = {"UP": 6, "DOWN": 19, "LEFT": 5, "RIGHT": 26,
+        "OK": 13, "KEY1": 21, "KEY2": 20, "KEY3": 16}
+
 
 class WiFiLCDInterface:
     def __init__(self):
@@ -507,25 +512,11 @@ class WiFiLCDInterface:
         time.sleep(duration)
 
     def check_buttons(self):
-        """Check for button presses with non-blocking debouncing."""
-        if not hasattr(self, '_last_pressed'):
-            self._last_pressed = {}
-            self._button_states = {name: 1 for name in self.buttons.keys()}
-
-        current_time = time.time()
-        for name, pin in self.buttons.items():
-            current_state = GPIO.input(pin)
-
-            # Detect falling edge (1 -> 0)
-            if self._button_states[name] == 1 and current_state == 0:
-                if current_time - self._last_pressed.get(name, 0) > 0.15:
-                    self._last_pressed[name] = current_time
-                    self._button_states[name] = current_state
-                    return name
-
-            self._button_states[name] = current_state
-
-        return None
+        """Check for button presses, respects flip setting."""
+        btn = get_button(PINS, GPIO)
+        if btn == "OK":
+            return "CENTER"
+        return btn
 
     def update_display(self):
         """Update the LCD display based on current menu."""

--- a/wifi/wifi_lcd_interface.py
+++ b/wifi/wifi_lcd_interface.py
@@ -28,17 +28,13 @@ try:
     import LCD_1in44, LCD_Config
     from PIL import Image, ImageDraw, ImageFont
     import RPi.GPIO as GPIO
-    from payloads._input_helper import get_button
+    from payloads._input_helper import get_virtual_button, _flip
     from wifi_manager import WiFiManager
     from payloads._display_helper import ScaledDraw, scaled_font
     LCD_AVAILABLE = True
 except Exception as e:
     print(f"LCD not available: {e}")
     LCD_AVAILABLE = False
-
-PINS = {"UP": 6, "DOWN": 19, "LEFT": 5, "RIGHT": 26,
-        "OK": 13, "KEY1": 21, "KEY2": 20, "KEY3": 16}
-
 
 class WiFiLCDInterface:
     def __init__(self):
@@ -109,6 +105,8 @@ class WiFiLCDInterface:
 
         for pin in self.buttons.values():
             GPIO.setup(pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+        self._button_states = {pin: 1 for pin in self.buttons.values()}
+        self._last_pressed = {}
 
     def refresh_data(self):
         """Refresh networks and profiles."""
@@ -512,11 +510,26 @@ class WiFiLCDInterface:
         time.sleep(duration)
 
     def check_buttons(self):
-        """Check for button presses, respects flip setting."""
-        btn = get_button(PINS, GPIO)
-        if btn == "OK":
-            return "CENTER"
-        return btn
+        """Check for button presses with falling-edge detection, respects flip setting."""
+        virtual = get_virtual_button()
+        if virtual:
+            if virtual == "OK":
+                return "CENTER"
+            return virtual
+
+        now = time.time()
+        for name, pin in self.buttons.items():
+            state = GPIO.input(pin)
+            if self._button_states[pin] == 1 and state == 0:
+                if now - self._last_pressed.get(pin, 0) > 0.15:
+                    self._last_pressed[pin] = now
+                    self._button_states[pin] = state
+                    flipped = _flip(name)
+                    if flipped == "OK":
+                        return "CENTER"
+                    return flipped
+            self._button_states[pin] = state
+        return None
 
     def update_display(self):
         """Update the LCD display based on current menu."""


### PR DESCRIPTION
Fix 5 payloads where physical button presses were not flipped when the display is rotated 180°, causing UP/DOWN/LEFT/RIGHT and KEY1/KEY3 to be reversed.

- wifi_lcd_interface.py: falling-edge detection + _flip() for orientation #60 
- sdr_subghz.py: raw GPIO loop -> get_button() + debounce
- sdr_adsb.py: same as sdr_subghz
- honeypot.py: dual virtual/GPIO paths -> single get_button() call
- fast_wifi_switcher.py: _flip() GPIO button names in read_buttons_fast()